### PR TITLE
Fix: Packages in array

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -13,8 +13,8 @@ type Local struct {
 	StartChar int `json:"start-char"`
 	EndChar   int `json:"end-char"`
 
-	File      string `json:"file"`
-	Package   string `json:"package"`
-	Module    string `json:"module"`
-	Workspace string `json:"workspace"`
+	File      string   `json:"file"`
+	Packages  []string `json:"package"`
+	Module    string   `json:"module"`
+	Workspace string   `json:"workspace"`
 }

--- a/error-struct/local-names.go
+++ b/error-struct/local-names.go
@@ -2,6 +2,7 @@ package errorstruct
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rantool-team/go-error/context"
 	"github.com/rantool-team/go-error/language"
@@ -15,8 +16,10 @@ var LocalDemonstrationLineChar = func(local context.Local) language.MessageSet {
 }
 
 var LocalDemonstrationFileModPackWorkspace = func(local context.Local) language.MessageSet {
+	var packages = strings.Join(local.Packages, "/")
+
 	return language.MessageSet{
-		Portuguese: fmt.Sprintf("Arquivo: %s, Pacote: %s, Modulo: %s, Worskpace: %s", local.File, local.Package, local.Module, local.Workspace),
-		English:    fmt.Sprintf("File: %s, Package: %s, Module: %s, Worskpace: %s", local.File, local.Package, local.Module, local.Workspace),
+		Portuguese: fmt.Sprintf("Arquivo: %s, Pacote: %s, Modulo: %s, Worskpace: %s", local.File, packages, local.Module, local.Workspace),
+		English:    fmt.Sprintf("File: %s, Package: %s, Module: %s, Worskpace: %s", local.File, packages, local.Module, local.Workspace),
 	}
 }


### PR DESCRIPTION
Normally in Go languages, an folder that is a package, can have other packages. Because of it, we are using all list of packages. 